### PR TITLE
Use a lazy val for (resourceListing, apiListingMap) tuple in SwaggerHttp...

### DIFF
--- a/src/main/scala/com/gettyimages/spray/swagger/SwaggerHttpService.scala
+++ b/src/main/scala/com/gettyimages/spray/swagger/SwaggerHttpService.scala
@@ -45,7 +45,7 @@ trait SwaggerHttpService extends HttpService with Logging with Json4sSupport {
   
   implicit def json4sFormats: Formats = DefaultFormats
  
-  private val (resourceListing, apiListingMap) = 
+  private lazy val (resourceListing, apiListingMap) =
     (new SwaggerApiBuilder(
         swaggerVersion, apiVersion, baseUrl, apiTypes, modelTypes,
         apiInfo = SwaggerHttpService.this.apiInfo, authorizations = SwaggerHttpService.this.authorizations

--- a/src/test/scala/com/gettyimages/spray/swagger/SwaggerHttpServiceSpec.scala
+++ b/src/test/scala/com/gettyimages/spray/swagger/SwaggerHttpServiceSpec.scala
@@ -1,0 +1,43 @@
+package com.gettyimages.spray.swagger
+
+import org.scalatest.FunSpec
+import akka.actor.{ActorRefFactory, ActorSystem}
+import org.scalatest.matchers.ShouldMatchers
+import scala.reflect.runtime.universe._
+import spray.routing.Route
+
+/**
+ * Created by l-chan on 3/10/14.
+ */
+class SwaggerHttpServiceSpec extends FunSpec with ShouldMatchers {
+
+  val context = ActorSystem("test")
+
+  describe("initialization") {
+    it("should not throw exceptions when implemented with defs") {
+      new SwaggerHttpService {
+        def actorRefFactory = context
+        def apiTypes = Seq(typeOf[DictHttpService])
+        def modelTypes = Seq()
+        def apiVersion = "1.0"
+        def swaggerVersion = "1.2"
+        def baseUrl = ""
+        def specPath = ""
+        def resourcePath = ""
+      }
+    }
+    it("should not throw exceptions when implemented with vals") {
+      new SwaggerHttpService {
+        val actorRefFactory = context
+        val apiTypes = Seq(typeOf[DictHttpService])
+        val modelTypes = Seq()
+        val apiVersion = "1.0"
+        val swaggerVersion = "1.2"
+        val baseUrl = ""
+        val specPath = ""
+        val resourcePath = ""
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
...Service

This allows programmers to implement the abstract methods as either `def`s or `val`s
without running into runtime NPE due to the confusing-ish way that Scala constructs
a class. In 'most cases' you can mix the two, but not in this case.

I personally ran into this [here](https://github.com/gettyimages/spray-swagger/issues/6) and tracked my issue down to this line.
