### PR TITLE
cross-build for scala-2.10 and scala-2.11, updated dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,19 +4,26 @@ organization := "com.gettyimages"
 
 name := "spray-swagger"
 
-scalaVersion := "2.10.3"
+scalaVersion := "2.10.4"
+
+crossScalaVersions := Seq("2.10.3", "2.11.0")
+
+libraryDependencies += { scalaBinaryVersion.value match {
+ 	case "2.10" => ("io.spray"  % "spray-routing" % "1.3.1")
+	case "2.11" => ("io.spray" %% "spray-routing" % "1.3.1-20140423")
+  }
+ }
 
 libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "2.1.0" % "test",
-  "com.wordnik" %% "swagger-annotations" % "1.3.0",
+  "org.scalatest" %% "scalatest" % "2.1.5" % "test",
+  "com.wordnik" % "swagger-annotations_2.10" % "1.3.0",
   "javax.ws.rs" % "jsr311-api" % "1.1.1",
-  "com.typesafe" %% "scalalogging-slf4j" % "1.0.1",
-  "com.typesafe.akka" %% "akka-actor" % "2.3.0",
-  "org.json4s" %% "json4s-jackson" % "3.2.4",
-  "io.spray" % "spray-routing" % "1.3.0",
+  "com.typesafe.akka" %% "akka-actor" % "2.3.2",
+  "org.json4s" %% "json4s-native" % "3.2.9",
+  "org.json4s" %% "json4s-jackson" % "3.2.9",
   "joda-time" % "joda-time" % "2.2",
   "org.joda" % "joda-convert" % "1.3.1",
-  "com.typesafe" %% "scalalogging-slf4j" % "1.0.1"
+  "com.typesafe.scala-logging" %% "scala-logging-slf4j" % "2.1.2"
 )
 
 resolvers += "spray repo" at "http://repo.spray.io"

--- a/src/main/scala/com/gettyimages/spray/swagger/SwaggerApiBuilder.scala
+++ b/src/main/scala/com/gettyimages/spray/swagger/SwaggerApiBuilder.scala
@@ -23,7 +23,7 @@ import com.wordnik.swagger.annotations.ApiImplicitParams
 import com.wordnik.swagger.annotations.ApiOperation
 import spray.routing.HttpService
 import com.wordnik.swagger.annotations.ApiResponses
-import com.typesafe.scalalogging.slf4j.Logging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import javax.ws.rs.Path
 
 case class ApiMissingPropertyException(msg: String) extends Exception(msg)
@@ -35,13 +35,13 @@ class SwaggerApiBuilder(
   modelTypes: Seq[Type],
   apiInfo: Option[ApiInfo] = None,
   authorizations: Option[Map[String, Authorization]]  = None
-) extends Logging {
+) extends StrictLogging {
 
 
   implicit val mirror = runtimeMirror(getClass.getClassLoader)
 
   private val modelJsonMap = new SwaggerModelBuilder(modelTypes).buildAll
-
+  
   logger.debug(s"ModelJsonMap: $modelJsonMap")
 
   val swaggerApiAnnotations = apiTypes.map(apiType => getClassAnnotation[Api](apiType) match {

--- a/src/main/scala/com/gettyimages/spray/swagger/SwaggerHttpService.scala
+++ b/src/main/scala/com/gettyimages/spray/swagger/SwaggerHttpService.scala
@@ -21,13 +21,13 @@ import scala.reflect.runtime.universe.Type
 import org.json4s.DefaultFormats
 import org.json4s.Formats
 
-import com.typesafe.scalalogging.slf4j.Logging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 
 import spray.httpx.Json4sSupport
 import spray.routing.Directive.pimpApply
 import spray.routing.{PathMatcher, HttpService, Route}
 
-trait SwaggerHttpService extends HttpService with Logging with Json4sSupport {
+trait SwaggerHttpService extends HttpService with StrictLogging with Json4sSupport {
 
   def apiTypes: Seq[Type]
   def modelTypes: Seq[Type]

--- a/src/main/scala/com/gettyimages/spray/swagger/SwaggerModelBuilder.scala
+++ b/src/main/scala/com/gettyimages/spray/swagger/SwaggerModelBuilder.scala
@@ -22,10 +22,10 @@ import com.wordnik.swagger.annotations.ApiModel
 import java.util.Date
 import com.wordnik.swagger.annotations.ApiModelProperty
 import org.joda.time.DateTime
-import com.typesafe.scalalogging.slf4j.Logging
+import com.typesafe.scalalogging.slf4j.StrictLogging
 import scala.collection.immutable.ListMap
 
-class SwaggerModelBuilder(modelTypes: Seq[Type])(implicit mirror: Mirror) extends Logging {
+class SwaggerModelBuilder(modelTypes: Seq[Type])(implicit mirror: Mirror) extends StrictLogging {
 
   //validate models
   val modelAnnotationTypesMap = modelTypes.map(tpe => { getClassAnnotation[ApiModel](tpe) match {

--- a/src/test/scala/com/gettyimages/spray/swagger/SwaggerModelBuilderSpec.scala
+++ b/src/test/scala/com/gettyimages/spray/swagger/SwaggerModelBuilderSpec.scala
@@ -173,13 +173,13 @@ object SwaggerModelBuilderSpecValues {
   final val AllowableDescription = "allowableDesciption"
 }
 
-case class TestModelWithNoAnnotation
+case class TestModelWithNoAnnotation()
 
 @Deprecated
-case class TestModelWithWrongAnnotation
+case class TestModelWithWrongAnnotation()
 
 @ApiModel
-case class TestModelEmptyAnnotation
+case class TestModelEmptyAnnotation()
 
 @ApiModel
 sealed trait TestModelParent {
@@ -252,8 +252,8 @@ case class TestModelNode(
   value: Option[String]
 )
 
-case class A extends Letter
-case class B extends Letter
+case class A() extends Letter
+case class B() extends Letter
 
 @ApiModel(
   subTypes = Array(classOf[String], classOf[B])


### PR DESCRIPTION
First attempt at scala-2.11 compatibilty.
It compiles, tests and works
Spray currently publishes only a nightly with 2.11 support, so there is a need for special handling of spray dependency.

Another breaking change is update of scala-logging to its successor - that causes some changes in mixed traits.

Final changes are those required by scala itself - in 2.11 case classes without parameter lists are forbidden

If this PR is merged, I think it should be a version bump due to incompatility with previous scalalogging.
