### PR TITLE
Update for a new version of scala-logging

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ libraryDependencies ++= Seq(
   "org.json4s" %% "json4s-native" % "3.2.9",
   "joda-time" % "joda-time" % "2.2",
   "org.joda" % "joda-convert" % "1.3.1",
-  "com.typesafe.scala-logging" %% "scala-logging-slf4j" % "2.1.2",
+  "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0",
   "javax.ws.rs" % "jsr311-api" % "1.1.1"
 )
 

--- a/src/main/scala/com/gettyimages/spray/swagger/SprayApiReader.scala
+++ b/src/main/scala/com/gettyimages/spray/swagger/SprayApiReader.scala
@@ -21,7 +21,7 @@ import javax.ws.rs._
 import scala.collection.mutable.ListBuffer
 import scala.reflect.runtime.universe.Type
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 import com.wordnik.swagger.annotations._
 import com.wordnik.swagger.config._
 import com.wordnik.swagger.core._

--- a/src/main/scala/com/gettyimages/spray/swagger/SprayApiScanner.scala
+++ b/src/main/scala/com/gettyimages/spray/swagger/SprayApiScanner.scala
@@ -19,7 +19,7 @@ import scala.reflect.runtime.universe._
 import com.wordnik.swagger.annotations.Api
 import com.wordnik.swagger.core.SwaggerContext
 import com.wordnik.swagger.config._
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 import spray.routing.HttpService
 
 class SprayApiScanner(apiTypes: Seq[Type])

--- a/src/main/scala/com/gettyimages/spray/swagger/SwaggerApiBuilder.scala
+++ b/src/main/scala/com/gettyimages/spray/swagger/SwaggerApiBuilder.scala
@@ -19,7 +19,7 @@ package com.gettyimages.spray.swagger
 import com.wordnik.swagger.config._
 import com.wordnik.swagger.reader._
 import com.wordnik.swagger.core.util.ReaderUtil
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 import com.wordnik.swagger.model._
 import scala.reflect.runtime.universe._
 import com.wordnik.swagger.converter.ModelConverters

--- a/src/main/scala/com/gettyimages/spray/swagger/SwaggerHttpService.scala
+++ b/src/main/scala/com/gettyimages/spray/swagger/SwaggerHttpService.scala
@@ -21,7 +21,7 @@ import scala.reflect.runtime.universe.Type
 import org.json4s.DefaultFormats
 import org.json4s.Formats
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 
 import spray.routing.{ PathMatcher, HttpService, Route }
 import com.wordnik.swagger.model._


### PR DESCRIPTION
Including spray-swagger to any project using scala-logging in version > "2" causes "ImplementationClass" errors during startup.
Can we bump scala-logging version to "3"?