### PR TITLE
Change Spray version to 1.3.2 and change spray-routing to spray-routing-...

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,8 +9,8 @@ scalaVersion := "2.11.2"
 crossScalaVersions := Seq("2.10.4", "2.11.2")
 
 libraryDependencies ++= Seq(
-  "io.spray" %% "spray-routing" % "1.3.1",
-  "io.spray" %% "spray-testkit" % "1.3.1" % "test",
+  "io.spray" %% "spray-routing-shapeless2" % "1.3.2",
+  "io.spray" %% "spray-testkit" % "1.3.2" % "test",
   "org.scalatest" %% "scalatest" % "2.2.0" % "test" ,
   "com.wordnik" %% "swagger-core" % "1.3.10" excludeAll( ExclusionRule(organization = "org.json4s"),  ExclusionRule(organization="org.fasterxml*") ),
   "com.typesafe.akka" %% "akka-actor" % "2.3.3",


### PR DESCRIPTION
Currently, spray-swagger relies on Spray 1.3.1 which uses an old version of Shapeless (1.2.4). In order to resolve conflict cross-version suffixes when trying to use shapeless 2.0.0, this PR bumps Spray to 1.3.2 and uses the `spray-routing-shapeless2` release as described in the [Spray docs](http://spray.io/project-info/current-versions/#shapeless-versions) which says: 

> For shapeless 2.0.0 you should use spray 1.3.2 (Scala 2.10 or Scala 2.11) and the spray-routing-shapeless2 module instead of spray-routing.

You may have to maintain two different branches the same way the Spray project does, with one using `spray-routing` and the other using `spray-routing-shapeless2` for those that wish to use shapeless 2.0.0.
