### PR TITLE
Removed the dependency on unused lazy logging trait

### DIFF
--- a/src/main/scala/com/gettyimages/spray/swagger/SwaggerHttpService.scala
+++ b/src/main/scala/com/gettyimages/spray/swagger/SwaggerHttpService.scala
@@ -21,8 +21,6 @@ import scala.reflect.runtime.universe.Type
 import org.json4s.DefaultFormats
 import org.json4s.Formats
 
-import com.typesafe.scalalogging.LazyLogging
-
 import spray.routing.{ PathMatcher, HttpService, Route }
 import com.wordnik.swagger.model._
 import com.wordnik.swagger.core.util.JsonSerializer
@@ -32,8 +30,7 @@ import spray.http.MediaTypes.`application/json`
 import spray.http.StatusCodes.NotFound
 
 trait SwaggerHttpService
-    extends HttpService
-    with LazyLogging {
+    extends HttpService {
 
   def apiTypes: Seq[Type]
 


### PR DESCRIPTION
The Swagger HTTP Service is to be pulled in as a trait. It also pulls in LazyLogging (which it does not use). Therefore I have to pull in LazyLogging.

I am working on a project where my HTTP Service already has a lazy val logger of a different type which is also pulled in as a trait. I can not change that. Since Swagger HTTP service is not using it I vote for removing it, as is done in this PR.

A side note: The HTTP Service is to be pulled into an actor, if it really needed logging it should use ActorLogging (and maybe use the cake pattern for that).
