### PR TITLE
service and builder made extensible

### DIFF
--- a/src/main/scala/com/gettyimages/spray/swagger/SwaggerApiBuilder.scala
+++ b/src/main/scala/com/gettyimages/spray/swagger/SwaggerApiBuilder.scala
@@ -31,10 +31,17 @@ class SwaggerApiBuilder(
 ) extends ReaderUtil
     with LazyLogging {
 
-  val scanner = new SprayApiScanner(apiTypes)
-  val reader = new SprayApiReader()
+  val scanner = buildScanner
 
-  val listings: Map[String, ApiListing] = {
+  val reader = buildReader
+
+  val listings: Map[String, ApiListing] = buildListings
+
+  protected def buildScanner: SprayApiScanner = new SprayApiScanner(apiTypes)
+
+  protected def buildReader: SprayApiReader = new SprayApiReader()
+
+  protected def buildListings: Map[String, ApiListing] = {
     logger.info("loading api metadata")
     val classes = scanner match {
       case scanner: Scanner => scanner.classes()

--- a/src/main/scala/com/gettyimages/spray/swagger/SwaggerHttpService.scala
+++ b/src/main/scala/com/gettyimages/spray/swagger/SwaggerHttpService.scala
@@ -45,7 +45,9 @@ trait SwaggerHttpService
   def apiInfo: Option[ApiInfo] = None
   def authorizations: List[AuthorizationType] = List()
 
-  private val api =
+  protected val api: SwaggerApiBuilder = buildApi
+
+  protected def buildApi: SwaggerApiBuilder =
     new SwaggerApiBuilder(
       new SwaggerConfig(
         apiVersion,


### PR DESCRIPTION
Currently, it is not possible to easily extend service and builder classes with custom functionality. For instance, I have a need to provide extra `ApiListing`s created directly or from a different source model. This little adjustment will make this possible with minimum effort.